### PR TITLE
Fixed an issue with scrollbars on fixed header tables

### DIFF
--- a/js/tableutils.js
+++ b/js/tableutils.js
@@ -4194,6 +4194,14 @@
 				fastAddClass(rows[i], 'oddRow');
 			}		
 			
+			// If the wrapper is wider than the table, then the table has a scrollbar
+			// In this case, if we have a fixed header, we pad it to the width of the scrollbar
+			var scrollWidth = $('#mainTableWrapper_' + tableID).width() - $('#' + tableID).width();
+			if (scrollWidth > 0) {
+			    $('#fixedHeader_' + tableID).css({ 'padding-right': scrollWidth + 'px' });
+			} else {
+			    $('#fixedHeader_' + tableID).css({ 'padding-right': '0px' });
+			}
 			stopTimer('Applying style');
 		};	
 		


### PR DESCRIPTION
OK this may be only happening to me.
With a fixed header and pagination, if i navigate to a page where there is more content, the table scrolls, so it has a scrollbar, which changes the sizes of the columns. But the fixed header doesn't change, so the columns fall out of alignment.
Better explained with a screenshot : http://testdam.correosolucion.com/github/scrollbar.png
So i added a little hack to applyTableStyling() that calculates the scrollbar's width and pads the header accordingly.
Result : http://testdam.correosolucion.com/github/scrollbar2.png
